### PR TITLE
AM-144 Fix regex to allow ports and paths in push endpoint validation

### DIFF
--- a/src/UpdateSub.js
+++ b/src/UpdateSub.js
@@ -132,7 +132,7 @@ class UpdateSub extends Component {
     validatePushEndpoint(value) {
         let errors = this.state.errors;
         if ( value !== "" &&
-            !/^((https):\/\/)([w|W]{3}\.)?[a-zA-Z0-9\-.]{3,}\.[a-zA-Z]{2,}(\.[a-zA-Z]{2,})?$/i.test(
+            !/^((https):\/\/)([w|W]{3}\.)?[a-zA-Z0-9\-.]{3,}\.[a-zA-Z]{2,}(\.[a-zA-Z]{2,})?(\:[0-9]{2,})?(\/[a-zA-Z0-9\-\.]{1,})*$/i.test(
                 value
             )
         ) {


### PR DESCRIPTION
Updated the regex that checks the push endpoint validation.

Added optional port check that starts with ":" and has at least 2 number length
- https://test.com.gr:89 Accepted
- https://test.com.gr:8  Declined
- https://test.com.gr:  Declined

Added optional recursive path that begins with "/" and should have at least 1 char from [a-zA-Z0-9]
- https://test.com.gr Accepted
- https://test.com.gr/ Declined
- https://test.com.gr// Declined
- https://test.com.gr/a Accepted
- https://test.com.gr/a/b/c Accepted
- https://test.com.gr/index.php Declined (Because of the dot)