### PR TITLE
AM-145 Fix verify status in SubDetails

### DIFF
--- a/src/SubDetails.js
+++ b/src/SubDetails.js
@@ -269,14 +269,14 @@ class SubDetails extends React.Component {
                 <span>  - type:</span><code>{this.state.sub.pushConfig.retryPolicy.type}</code><br/>
                 <span>  - period:</span><code>{this.state.sub.pushConfig.retryPolicy.period}</code>
                 </li>
-                { this.state.sub.pushConfig.verify && 
+                { this.state.sub.pushConfig.verified &&
                  <li className="list-group-item py-2 ">
                      Push endpoint <strong style={{color:"green"}}>verified!</strong><br/>
                      <strong>Status</strong>{this.state.sub.pushConfig.status}
 
                  </li>
                 }
-                { !this.state.sub.pushConfig.verify && 
+                { !this.state.sub.pushConfig.verified &&
                  <li className="list-group-item py-2 ">
                      Push endpoint <strong style={{color:"red"}}>unverified!</strong><br/>
                      


### PR DESCRIPTION
The endpoint returns a property named "verified" but in the UI we were checking for a field named "verify". This caused the UI to show false status. This PR fixed the property name check to show the correct status.