### PR TITLE
AM-149 fix on delete sub return to project subs

### DIFF
--- a/src/SubDetails.js
+++ b/src/SubDetails.js
@@ -160,8 +160,8 @@ class SubDetails extends React.Component {
 
     apiDelete(project, sub) {
         let comp = this;
-        this.DM.subDelete(project, sub).then(r => {
-            if (r.done) {
+        this.DM.subDelete(project, sub).then(done => {
+            if (done) {
                 NotificationManager.info("Subscription Deleted", null, 1000);
                 setTimeout(function() {
                     comp.props.history.push("/subs#" + project);


### PR DESCRIPTION
On a successful delete of a subscription the redirection was not working properly to redirect the user to the list of the project's subs. I followed what the delete topic did to fix this issue. 