### PR TITLE
AM-152 Fix empty project array

### DIFF
--- a/src/Authen.js
+++ b/src/Authen.js
@@ -29,14 +29,18 @@ class Authen {
             })
             .then(json => {
                 if (json.error === undefined) {
-                    let serviceRoles = ""
+                    let serviceRoles = []
+                    let projects = []
                     if (json.service_roles) {
                         serviceRoles = json.service_roles
+                    }
+                    if (json.projects) {
+                        projects = json.projects
                     }
                     this.setLogin(
                         json.name,
                         token,
-                        json.projects,
+                        projects,
                         serviceRoles
                     );
                     if (callback !== undefined) {


### PR DESCRIPTION
When a user that didn't belong at any projects and was trying to log in caused a failure in the UI.

The response didn't necessarily had the projects field in the response as a result when the UI was trying to assign the projects in the localstorage there was an error