### PR TITLE
AM-215 Display pulled message content in a read only text bar

### DIFF
--- a/src/SubPull.js
+++ b/src/SubPull.js
@@ -260,9 +260,9 @@ class SubPull extends Component {
                                          <em style={{color:"#888888"}}><FontAwesomeIcon icon="clock" /> <code style={{color:"grey"}}>{msg["publishTime"]}</code></em>
                                          </div>
                                          <div className="row mx-1">
-                                         <code className="form-control mt-2 mb-2">
+                                         <textarea className="form-control" rows="4" readOnly = {true} style={{backgroundColor:"white"}}>
                                              {atob(msg["data"])}
-                                         </code>
+                                         </textarea>
                                          <div>{attrList}</div>
                                          </div>
                                          


### PR DESCRIPTION
Current Pull messages view uses a `<code>` element to display message's content which overflows badly to the other elements of the page (in case of large messages)

Replace `<code>` element with a read only `<textarea>` with an ample initial row size of 4 giving the ability to the user to resize the content on demand and avoid bad overflows